### PR TITLE
Added functionality to have different hyperparameters in different models

### DIFF
--- a/DevRscripts/runFONSEmodel.R
+++ b/DevRscripts/runFONSEmodel.R
@@ -14,7 +14,7 @@ parameter <- initializeParameterObject(genome, sphi_init, numMixtures, geneAssig
                                        mixture.definition = mixDef)
 
 # initialize MCMC object
-samples <- 100
+samples <- 20
 thining <- 10
 adaptiveWidth <- 10
 mcmc <- initializeMCMCObject(samples=samples, thining=thining, adaptive.width=adaptiveWidth, 
@@ -25,7 +25,7 @@ model <- initializeModelObject(parameter, "FONSE")
 setRestartSettings(mcmc, "restartFile.rst", adaptiveWidth, TRUE)
 #run mcmc on genome with parameter using model
 system.time(
-  runMCMC(mcmc, genome, model, 4)
+  runMCMC(mcmc, genome, model)
 )
 
 #plots log likelihood trace, possibly other mcmc diagnostics in the future

--- a/ribModel/src/CovarianceMatrix.cpp
+++ b/ribModel/src/CovarianceMatrix.cpp
@@ -93,37 +93,51 @@ void CovarianceMatrix::choleskiDecomposition()
 }
 
 
-void CovarianceMatrix::calculateCovarianceMatrixFromTraces(std::vector<std::vector <std::vector<double>>> trace, unsigned geneIndex, unsigned curSample, unsigned adaptiveWidth)
+/*void CovarianceMatrix::calculateCovarianceMatrixFromTraces(std::vector <std::vector <std::vector<double>>> mutationTrace, std::vector <std::vector <std::vector <double>>> selectionTrace,
+	unsigned aaIndex, unsigned curSample, unsigned adaptiveWidth)
 {
     // calculate all means
-    unsigned numVariates = trace.size(); // <- number of mixture elements or number of selection categories
-    double* means = new double[numVariates]();
+    unsigned numMutation = mutationTrace.size();
+	unsigned numSelection = selectionTrace.size();// <- number of mixture elements or number of selection categories
+    double* mutationMeans = new double[numMutation]();
+	double* selectionMeans = new double[numSelection]();
+	std::array <unsigned, 2> *codonRange;
     unsigned start = curSample - adaptiveWidth;
     // calculate all means from trace
-    for(unsigned i = 0u; i < numVariates; i++)
+	//codonRange = &SequenceSummary::
+    for(unsigned i = 0u; i < numMutation; i++)
     {
         for(unsigned j = start; j < curSample; j++)
         {
-            means[i] += trace[i][j][geneIndex];
+            mutationMeans[i] += mutationTrace[i][j][j];
         }
-        means[i] /= adaptiveWidth;
+        mutationMeans[i] /= adaptiveWidth;
     }
 
+	for (unsigned i = 0u; i < numSelection; i++)
+	{
+		for (unsigned j = start; j < curSample; j++) {
+			selectionMeans[i] += mutationTrace[i][j][geneIndex];
+		}
+	}
 
-    for(unsigned i = 0u; i < numVariates; i++)
+
+    for(unsigned i = 0u; i < _numVariates; i++)
     {
-        for (unsigned k = 0u; k < numVariates; k++)
+        for (unsigned k = 0u; k < _numVariates; k++)
         {
             double nonNormalizedCovariance = 0.0; // missing term 1/(n-1)
             for(unsigned j = start; j < curSample; j++)
             {
                 nonNormalizedCovariance += (trace[i][j][geneIndex] - means[i]) * (trace[k][j][geneIndex] - means[k]);
             }
-            covMatrix[i * numVariates + k] = (1.0/(adaptiveWidth - 1.0)) * nonNormalizedCovariance;
+            covMatrix[i * _numVariates + k] = (1.0/(adaptiveWidth - 1.0)) * nonNormalizedCovariance;
         }
 
     }
 }
+*/
+
 std::vector<double> CovarianceMatrix::transformIidNumersIntoCovaryingNumbers(std::vector <double> iidnumbers)
 {
     std::vector<double> covnumbers;

--- a/ribModel/src/FONSEParameter.cpp
+++ b/ribModel/src/FONSEParameter.cpp
@@ -920,6 +920,11 @@ void FONSEParameter::proposeCodonSpecificParameter()
 
 }
 
+void FONSEParameter::proposeHyperParameters()
+{
+	Sphi_proposed = std::exp(randNorm(std::log(Sphi), std_sphi));
+}
+
 void FONSEParameter::updateCodonSpecificParameter(std::string grouping)
 {
 	std::array <unsigned, 2> aaRange = SequenceSummary::AAToCodonRange(grouping, true);

--- a/ribModel/src/Genome.cpp
+++ b/ribModel/src/Genome.cpp
@@ -9,6 +9,7 @@
 Genome::Genome()
 {
 	//ctor
+	numGenesWithPhi = 0;
 }
 
 Genome::~Genome()
@@ -21,6 +22,7 @@ Genome& Genome::operator=(const Genome& rhs)
 	if (this == &rhs) return *this; // handle self assignment
 	genes = rhs.genes;
 	simulatedGenes = rhs.simulatedGenes;
+	numGenesWithPhi = rhs.numGenesWithPhi;
 	//assignment operator
 	return *this;
 }
@@ -353,6 +355,7 @@ void Genome::readObservedPhiValues(std::string filename, bool byId)
 						}
 						std::string val = tmp.substr(pos + 1, pos2 - (pos + 1));
 						it->second -> observedPhiValues.push_back(std::atof(val.c_str())); //make vector private again
+						if (it->second->observedPhiValues.size() == 1) numGenesWithPhi++;
 						pos = pos2;
 					}
 				}
@@ -381,6 +384,7 @@ void Genome::readObservedPhiValues(std::string filename, bool byId)
 					}
 					std::string val = tmp.substr(pos + 1, pos2 - (pos + 1));
 					genes[geneIndex].observedPhiValues.push_back(std::atof(val.c_str()));
+					if (genes[geneIndex].observedPhiValues.size() == 1) numGenesWithPhi++;
 					pos = pos2;
 				}
 				geneIndex++;

--- a/ribModel/src/Parameter.cpp
+++ b/ribModel/src/Parameter.cpp
@@ -759,16 +759,6 @@ void Parameter::InitializeSynthesisRate(std::vector<double> expression)
 
 }
 
-
-
-void Parameter::proposeSPhi()
-{
-	//Sphi_proposed = randLogNorm(Sphi, std_sphi);
-	// avoid adjusting probabilities for asymmetry of distribution
-	Sphi_proposed = std::exp(randNorm(std::log(Sphi), std_sphi));
-}
-
-
 void Parameter::proposeSynthesisRateLevels()
 {
 	unsigned numSynthesisRateLevels = currentSynthesisRateLevel[0].size();

--- a/ribModel/src/RFPModel.cpp
+++ b/ribModel/src/RFPModel.cpp
@@ -121,6 +121,29 @@ void RFPModel::calculateLogLikelihoodRatioPerGroupingPerCategory(std::string gro
 	logAcceptanceRatioForAllMixtures = logLikelihood_proposed - logLikelihood;
 }
 
+void RFPModel::calculateLogLikelihoodRatioForHyperParameters(unsigned numGenes, unsigned iteration, double & logProbabilityRatio)
+{
+	double currentSphi = getSphi(false);
+	double currentMPhi = -(currentSphi * currentSphi) / 2;
+	double lpr = logProbabilityRatio; // this variable is only needed because OpenMP doesn't allow variables in reduction clause to be reference
+	double proposedSphi = getSphi(true);
+	double proposedMPhi = -(proposedSphi * proposedSphi) / 2;
+
+#ifndef __APPLE__
+#pragma omp parallel for reduction(+:lpr)
+#endif
+	for (int i = 0; i < numGenes; i++)
+	{
+		unsigned mixture = getMixtureAssignment(i);
+		mixture = getSynthesisRateCategory(mixture);
+		double phi = getSynthesisRate(i, mixture, false);
+		lpr += std::log(Parameter::densityLogNorm(phi, proposedMPhi, proposedSphi)) - std::log(Parameter::densityLogNorm(phi, currentMPhi, currentSphi));
+	}
+
+	lpr -= (std::log(currentSphi) - std::log(proposedSphi));
+	logProbabilityRatio = lpr;
+}
+
 
 void RFPModel::simulateGenome(Genome &genome)
 {

--- a/ribModel/src/RFPParameter.cpp
+++ b/ribModel/src/RFPParameter.cpp
@@ -458,6 +458,11 @@ void RFPParameter::proposeCodonSpecificParameter()
 	}
 }
 
+void RFPParameter::proposeHyperParameters()
+{
+	Sphi_proposed = std::exp(randNorm(std::log(Sphi), std_sphi));
+}
+
 
 void RFPParameter::adaptCodonSpecificParameterProposalWidth(unsigned adaptationWidth)
 {

--- a/ribModel/src/ROCParameter.cpp
+++ b/ribModel/src/ROCParameter.cpp
@@ -961,6 +961,11 @@ void ROCParameter::proposeCodonSpecificParameter()
 
 }
 
+void ROCParameter::proposeHyperParameters()
+{
+	Sphi_proposed = std::exp(randNorm(std::log(Sphi), std_sphi));
+}
+
 std::vector<double> ROCParameter::propose(std::vector<double> currentParam, double (*proposal)(double a, double b),
 		double A, std::vector<double> B)
 {

--- a/ribModel/src/include/FONSE/FONSEModel.h
+++ b/ribModel/src/include/FONSE/FONSEModel.h
@@ -26,6 +26,7 @@ public:
 	virtual void calculateLogLikelihoodRatioPerGene(Gene& gene, unsigned geneIndex, unsigned k, double* logProbabilityRatio);
 	double calculateLogLikelihoodRatioPerAA(Gene& gene, std::string grouping, double *mutation, double *selection, double phiValue);
 	virtual void calculateLogLikelihoodRatioPerGroupingPerCategory(std::string grouping, Genome& genome, double& logAcceptanceRatioForAllMixtures);
+	virtual void calculateLogLikelihoodRatioForHyperParameters(unsigned numGenes, unsigned iteration, double &logProbabilityRatio);
 
 	//Parameter wrapper functions:
 	virtual void initTraces(unsigned samples, unsigned num_genes) { parameter->initAllTraces(samples, num_genes); }
@@ -38,7 +39,7 @@ public:
 	virtual void adaptCodonSpecificParameterProposalWidth(unsigned adaptiveWidth) { parameter->adaptCodonSpecificParameterProposalWidth(adaptiveWidth); }
 	virtual void updateCodonSpecificParameter(std::string grouping) { parameter->updateCodonSpecificParameter(grouping); }
 	virtual void updateCodonSpecificParameterTrace(unsigned sample, std::string grouping) { parameter->updateCodonSpecificParameterTrace(sample, grouping); }
-	virtual void proposeSPhi() { parameter->proposeSPhi(); }
+	virtual void proposeHyperParameters() { parameter->proposeHyperParameters(); }
 	virtual unsigned getMixtureAssignment(unsigned index) { return parameter->getMixtureAssignment(index); }
 	virtual unsigned getSynthesisRateCategory(unsigned mixture) { return parameter->getSynthesisRateCategory(mixture); }
 	virtual unsigned getSelectionCategory(unsigned mixture) { return parameter->getSelectionCategory(mixture); }

--- a/ribModel/src/include/FONSE/FONSEParameter.h
+++ b/ribModel/src/include/FONSE/FONSEParameter.h
@@ -97,6 +97,7 @@ class FONSEParameter : public Parameter
 		}
 
 		void proposeCodonSpecificParameter();
+		void proposeHyperParameters();
 		void getParameterForCategory(unsigned category, unsigned paramType, std::string aa, bool proposal, double *returnSet);
 
 		void adaptCodonSpecificParameterProposalWidth(unsigned adaptationWidth);

--- a/ribModel/src/include/FONSE/FONSETrace.h
+++ b/ribModel/src/include/FONSE/FONSETrace.h
@@ -9,8 +9,8 @@
 class FONSETrace : public Trace
 {
 private:
-	std::vector< std::vector< std::vector<double> > > mutationParameterTrace; //order: mutationcategoy, numparam, samples
-	std::vector< std::vector< std::vector<double> > > selectionParameterTrace; //order: selectioncategoy, numparam, samples
+	std::vector< std::vector< std::vector<double> > > mutationParameterTrace; //order: mutationcategory, numparam, samples
+	std::vector< std::vector< std::vector<double> > > selectionParameterTrace; //order: selectioncategory, numparam, samples
 
 public:
 	//Constructor & Destructors

--- a/ribModel/src/include/Genome.h
+++ b/ribModel/src/include/Genome.h
@@ -16,6 +16,7 @@ class Genome
 	private:
 		std::vector<Gene> genes;
 		std::vector<Gene> simulatedGenes;
+		unsigned numGenesWithPhi;
 	public:
 		//constructor/destructor
 		explicit Genome();

--- a/ribModel/src/include/RFP/RFPModel.h
+++ b/ribModel/src/include/RFP/RFPModel.h
@@ -25,7 +25,7 @@ class RFPModel: public Model {
 				double* logProbabilityRatio);
 		virtual void calculateLogLikelihoodRatioPerGroupingPerCategory(std::string grouping, Genome& genome,
 				double& logAcceptanceRatioForAllMixtures);
-
+		virtual void calculateLogLikelihoodRatioForHyperParameters(unsigned numGenes, unsigned iteration, double &logProbabilityRatio);
 
 		//Other functions:
 		void setParameter(RFPParameter &_parameter);
@@ -73,9 +73,9 @@ class RFPModel: public Model {
 		{
 			parameter->updateCodonSpecificParameterTrace(sample, codon);
 		}
-		virtual void proposeSPhi()
+		virtual void proposeHyperParameters()
 		{
-			parameter->proposeSPhi();
+			parameter->proposeHyperParameters();
 		}
 		virtual unsigned getMixtureAssignment(unsigned index)
 		{

--- a/ribModel/src/include/RFP/RFPParameter.h
+++ b/ribModel/src/include/RFP/RFPParameter.h
@@ -80,7 +80,7 @@ class RFPParameter: public Parameter {
 		std::vector<std::vector<double>> getCurrentAlphaParameter();
 		std::vector<std::vector<double>> getCurrentLambdaPrimeParameter();
 		void proposeCodonSpecificParameter();
-
+		void proposeHyperParameters();
 
 		//Proposal widths:
 		void adaptCodonSpecificParameterProposalWidth(unsigned adaptationWidth); //may make virtual

--- a/ribModel/src/include/ROC/ROCModel.h
+++ b/ribModel/src/include/ROC/ROCModel.h
@@ -22,6 +22,8 @@ class ROCModel : public Model
 	virtual void calculateLogLikelihoodRatioPerGene(Gene& gene, unsigned geneIndex, unsigned k, double* logProbabilityRatio);
 	virtual void calculateLogLikelihoodRatioPerGroupingPerCategory(std::string grouping, Genome& genome, double& logAcceptanceRatioForAllMixtures);
 	void simulateGenome(Genome &genome);
+	virtual void calculateLogLikelihoodRatioForHyperParameters(unsigned numGenes, unsigned iteration, double &logProbabilityRatio);
+
 
 	//Parameter wrapper functions:
 	virtual void initTraces(unsigned samples, unsigned num_genes) {parameter -> initAllTraces(samples, num_genes);}
@@ -34,7 +36,7 @@ class ROCModel : public Model
 	virtual void adaptCodonSpecificParameterProposalWidth(unsigned adaptiveWidth) {parameter->adaptCodonSpecificParameterProposalWidth(adaptiveWidth);}
 	virtual void updateCodonSpecificParameter(std::string grouping) {parameter->updateCodonSpecificParameter(grouping);}
 	virtual void updateCodonSpecificParameterTrace(unsigned sample, std::string grouping) {parameter->updateCodonSpecificParameterTrace(sample,grouping);}
-	virtual void proposeSPhi() {parameter->proposeSPhi();}
+	virtual void proposeHyperParameters() {parameter->proposeHyperParameters();}
 	virtual unsigned getMixtureAssignment(unsigned index) {return parameter->getMixtureAssignment(index);}
 	virtual unsigned getSynthesisRateCategory(unsigned mixture) {return parameter->getSynthesisRateCategory(mixture);}
 	virtual unsigned getSelectionCategory(unsigned mixture) {return parameter ->getSelectionCategory(mixture);}

--- a/ribModel/src/include/ROC/ROCParameter.h
+++ b/ribModel/src/include/ROC/ROCParameter.h
@@ -103,6 +103,7 @@ class ROCParameter : public Parameter
 
 		// poposal functions
 		void proposeCodonSpecificParameter();
+		void proposeHyperParameters();
 		void getParameterForCategory(unsigned category, unsigned parameter, std::string aa, bool proposal, double *returnValue);
 
 		void adaptCodonSpecificParameterProposalWidth(unsigned adaptationWidth);

--- a/ribModel/src/include/base/Model.h
+++ b/ribModel/src/include/base/Model.h
@@ -20,6 +20,7 @@ class Model
         virtual void calculateLogLikelihoodRatioPerGene(Gene& gene, unsigned geneIndex, unsigned k, double* logProbabilityRatio) = 0;
         virtual void calculateLogLikelihoodRatioPerGroupingPerCategory(std::string grouping, Genome& genome,
         		double& logAcceptanceRatioForAllMixtures) = 0;
+		virtual void calculateLogLikelihoodRatioForHyperParameters(unsigned numGenes, unsigned iteration, double &logProbabilityRatio) = 0;
 
 
 		//Other functions:
@@ -37,7 +38,7 @@ class Model
 		virtual void adaptCodonSpecificParameterProposalWidth(unsigned adaptiveWidth) = 0;
 		virtual void updateCodonSpecificParameter(std::string grouping) = 0;
 		virtual void updateCodonSpecificParameterTrace(unsigned sample, std::string grouping) = 0;
-		virtual void proposeSPhi() = 0;
+		virtual void proposeHyperParameters() = 0;
 		virtual unsigned getMixtureAssignment(unsigned index) = 0;
 		virtual unsigned getSynthesisRateCategory(unsigned mixture) = 0;
 		virtual unsigned getSelectionCategory(unsigned mixture) = 0;

--- a/ribModel/src/include/base/Parameter.h
+++ b/ribModel/src/include/base/Parameter.h
@@ -170,8 +170,8 @@ class Parameter {
 		virtual void updateMixtureAssignmentTrace(unsigned sample, unsigned geneIndex) = 0;
 		virtual void updateMixtureProbabilitiesTrace(unsigned samples) = 0;
 
-		// poposal functions
-		void proposeSPhi();
+		// proposal functions
+		virtual void proposeHyperParameters() = 0;
 		void proposeSynthesisRateLevels();
 		double getCurrentSynthesisRateProposalWidth(unsigned expressionCategory, unsigned geneIndex)
 		{


### PR DESCRIPTION
This is a big commit. Basically, I've moved the hyperparameter
calculations out of MCMC and into the respective models. As of now, the
only hyperparameter each model has is Sphi, but soon Aphi and Sepsilon
will be added. There is a new pure virtual function in Model called
calculateLogLikelihoodForHyperParameters, which is where you guys can do
your accept/reject calculations. This is already done for Sphi however.
Parameter also has a new function called proposeHyperParameters. That
one is self-explanatory.