### PR TITLE
With Phi run updates

### DIFF
--- a/ribModel/src/FONSEModel.cpp
+++ b/ribModel/src/FONSEModel.cpp
@@ -170,6 +170,11 @@ void FONSEModel::calculateLogLikelihoodRatioForHyperParameters(unsigned numGenes
 	logProbabilityRatio = lpr;
 }
 
+void FONSEModel::adaptHyperParameterProposalWidths(unsigned adaptiveWidth)
+{
+	adaptSphiProposalWidth(adaptiveWidth);
+}
+
 void FONSEModel::setParameter(FONSEParameter &_parameter)
 {
 	parameter = &_parameter;

--- a/ribModel/src/MCMCAlgorithm.cpp
+++ b/ribModel/src/MCMCAlgorithm.cpp
@@ -302,7 +302,7 @@ void MCMCAlgorithm::run(Genome& genome, Model& model, unsigned numCores)
 			acceptRejectHyperParameter(genome.getGenomeSize(), model, iteration);
 			if( ( (iteration + 1u) % adaptiveWidth) == 0u)
 			{
-				model.adaptSphiProposalWidth(adaptiveWidth);
+				model.adaptHyperParameterProposalWidths(adaptiveWidth);
 			}
 		}
 		// update expression level values

--- a/ribModel/src/Parameter.cpp
+++ b/ribModel/src/Parameter.cpp
@@ -750,6 +750,11 @@ void Parameter::InitializeSynthesisRate(std::vector<double> expression)
 
 }
 
+void Parameter::proposeSphi()
+{
+	Sphi_proposed = std::exp(randNorm(std::log(Sphi), std_sphi));
+}
+
 void Parameter::proposeSynthesisRateLevels()
 {
 	unsigned numSynthesisRateLevels = currentSynthesisRateLevel[0].size();

--- a/ribModel/src/RFPModel.cpp
+++ b/ribModel/src/RFPModel.cpp
@@ -181,3 +181,8 @@ void RFPModel::simulateGenome(Genome &genome)
 		genome.addGene(tmpGene, true);
 	}
 }
+
+void RFPModel::adaptHyperParameterProposalWidths(unsigned adaptiveWidth)
+{
+	adaptSphiProposalWidth(adaptiveWidth);
+}

--- a/ribModel/src/ROCTrace.cpp
+++ b/ribModel/src/ROCTrace.cpp
@@ -21,6 +21,7 @@ void ROCTrace::initROCTraces(unsigned samples, unsigned numMutationCategories, u
 {
 	initMutationParameterTrace(samples, numMutationCategories, numParam);
 	initSelectionParameterTrace(samples, numSelectionCategories, numParam);
+	initAphiTrace(samples);
 }
 
 
@@ -53,6 +54,11 @@ void ROCTrace::initSelectionParameterTrace(unsigned samples, unsigned numSelecti
 			selectionParameterTrace[category][i] = temp;
 		}
 	}
+}
+
+void ROCTrace::initAphiTrace(unsigned samples)
+{
+	AphiTrace.resize(samples);
 }
 
 

--- a/ribModel/src/include/FONSE/FONSEModel.h
+++ b/ribModel/src/include/FONSE/FONSEModel.h
@@ -45,6 +45,7 @@ public:
 	virtual unsigned getMutationCategory(unsigned mixture)  { return parameter->getMutationCategory(mixture); }
 	virtual double getSynthesisRate(unsigned index, unsigned mixture, bool proposed = false) { return parameter->getSynthesisRate(index, mixture, proposed); }
 	virtual double getCurrentSphiProposalWidth() { return parameter->getCurrentSphiProposalWidth(); }
+	virtual void adaptHyperParameterProposalWidths(unsigned adaptiveWidth);
 	virtual void updateSphi() { parameter->updateSphi(); }
 	virtual void updateSphiTrace(unsigned sample) { parameter->updateSphiTrace(sample); }
 	virtual void adaptSphiProposalWidth(unsigned adaptiveWidth) { parameter->adaptSphiProposalWidth(adaptiveWidth); }

--- a/ribModel/src/include/RFP/RFPModel.h
+++ b/ribModel/src/include/RFP/RFPModel.h
@@ -93,6 +93,7 @@ class RFPModel: public Model {
 		{
 			return parameter->getSynthesisRate(index, mixture, proposed);
 		}
+		virtual void adaptHyperParameterProposalWidths(unsigned adaptiveWidth);
 		virtual double getCurrentSphiProposalWidth()
 		{
 			return parameter->getCurrentSphiProposalWidth();

--- a/ribModel/src/include/ROC/ROCModel.h
+++ b/ribModel/src/include/ROC/ROCModel.h
@@ -11,10 +11,11 @@ class ROCModel : public Model
 	ROCParameter *parameter;
 	virtual void obtainCodonCount(SequenceSummary& seqsum, std::string curAA, int codonCount[]);
 	double calculateLogLikelihoodPerAAPerGene(unsigned numCodons, int codonCount[], double mutation[], double selection[], double phiValue);
+	bool withPhi;
 
     public:
 
-	ROCModel();
+	ROCModel(bool _withPhi);
 	virtual ~ROCModel();
 	void setParameter(ROCParameter &_parameter);
 	void calculateCodonProbabilityVector(unsigned numCodons, double mutation[], double selection[], double phi, double codonProb[]);
@@ -29,22 +30,28 @@ class ROCModel : public Model
 	virtual void initTraces(unsigned samples, unsigned num_genes) {parameter -> initAllTraces(samples, num_genes);}
 	virtual void writeRestartFile(std::string filename) {return parameter->writeEntireRestartFile(filename);}       
 	virtual double getSphi(bool proposed = false) {return parameter->getSphi(proposed);}
+	double getAphi(bool proposed = false) { return parameter->getAphi(proposed); }
 	virtual unsigned getNumMixtureElements() {return parameter->getNumMixtureElements();}
 	virtual double getCategoryProbability(unsigned i) {return parameter->getCategoryProbability(i);}
 	virtual void proposeCodonSpecificParameter() {parameter->proposeCodonSpecificParameter();}
 	virtual void adaptCodonSpecificParameterProposalWidth(unsigned adaptiveWidth) {parameter->adaptCodonSpecificParameterProposalWidth(adaptiveWidth);}
 	virtual void updateCodonSpecificParameter(std::string grouping) {parameter->updateCodonSpecificParameter(grouping);}
 	virtual void updateCodonSpecificParameterTrace(unsigned sample, std::string grouping) {parameter->updateCodonSpecificParameterTrace(sample,grouping);}
-	virtual void proposeHyperParameters() {parameter->proposeHyperParameters();}
+	virtual void proposeHyperParameters();
 	virtual unsigned getMixtureAssignment(unsigned index) {return parameter->getMixtureAssignment(index);}
 	virtual unsigned getSynthesisRateCategory(unsigned mixture) {return parameter->getSynthesisRateCategory(mixture);}
 	virtual unsigned getSelectionCategory(unsigned mixture) {return parameter ->getSelectionCategory(mixture);}
 	virtual unsigned getMutationCategory(unsigned mixture)  {return parameter ->getMutationCategory(mixture);}
 	virtual double getSynthesisRate(unsigned index, unsigned mixture, bool proposed = false) {return parameter->getSynthesisRate(index, mixture, proposed);}
 	virtual double getCurrentSphiProposalWidth() {return parameter->getCurrentSphiProposalWidth();}
+	double getCurrentAphiProposalWidth() { return parameter->getCurrentAphiProposalWidth(); }
+	virtual void adaptHyperParameterProposalWidths(unsigned adaptiveWidth);
 	virtual void updateSphi() {parameter->updateSphi();}
 	virtual void updateSphiTrace(unsigned sample) {parameter->updateSphiTrace(sample);}
 	virtual void adaptSphiProposalWidth(unsigned adaptiveWidth) {parameter->adaptSphiProposalWidth(adaptiveWidth);}
+	void updateAphi() { parameter->updateAphi(); }
+	void updateAphiTrace(unsigned sample) { parameter->updateAphiTrace(sample); }
+	void adaptAphiProposalWidth(unsigned adaptiveWidth) { parameter->adaptAphiProposalWidth(adaptiveWidth); }
 	virtual void proposeSynthesisRateLevels() {parameter->proposeSynthesisRateLevels();}
 	virtual unsigned getNumSynthesisRateCategories() {return parameter->getNumSynthesisRateCategories();}
 	virtual std::vector<unsigned> getMixtureElementsOfSelectionCategory(unsigned k) {return parameter->getMixtureElementsOfSelectionCategory(k);}
@@ -65,8 +72,6 @@ class ROCModel : public Model
 	std::vector<double> CalculateProbabilitiesForCodons(std::vector<double> mutation, std::vector<double> selection, double phi);
 
     protected:
-		double Aphi;
-		double Aphi_proposed;
 };
 
 #endif // ROCMODEL_H

--- a/ribModel/src/include/ROC/ROCParameter.h
+++ b/ribModel/src/include/ROC/ROCParameter.h
@@ -25,6 +25,10 @@ class ROCParameter : public Parameter
 
 		double phiEpsilon;
 		double phiEpsilon_proposed;
+		double Aphi;
+		double Aphi_proposed;
+		double std_Aphi;
+		double numAcceptForAphi;
 
 		std::vector<std::vector<double>> currentMutationParameter;
 		std::vector<std::vector<double>> proposedMutationParameter;
@@ -84,6 +88,7 @@ class ROCParameter : public Parameter
 
 
 		double getPreviousCodonSpecificProposalWidth(unsigned aa);
+		double getCurrentAphiProposalWidth() { return std_Aphi; }
 		// Phi epsilon functions
 		double getPhiEpsilon() {return phiEpsilon;}
 
@@ -91,10 +96,18 @@ class ROCParameter : public Parameter
 		// functions to manage codon specific parameter
 		void updateCodonSpecificParameter(std::string grouping);
 
-
+		// functions to manage Aphi
+		double getAphi(bool proposed = false) { return (proposed ? Aphi_proposed : Aphi); }
+		void setAphi(double aPhi) { Aphi = aPhi; }
+		void updateAphi()
+		{
+			Aphi = Aphi_proposed;
+			numAcceptForAphi++;
+		}
 
 		//update trace functions
 		virtual void updateSphiTrace(unsigned sample) {traces.updateSphiTrace(sample, Sphi);}
+		void updateAphiTrace(unsigned sample) { traces.updateAphiTrace(sample, Aphi); }
 		virtual void updateSynthesisRateTrace(unsigned sample, unsigned geneIndex){traces.updateSynthesisRateTrace(sample, geneIndex, currentSynthesisRateLevel);}
 		virtual void updateMixtureAssignmentTrace(unsigned sample, unsigned geneIndex) {traces.updateMixtureAssignmentTrace(sample, geneIndex, mixtureAssignment[geneIndex]);}
 		virtual void updateMixtureProbabilitiesTrace(unsigned samples) {traces.updateMixtureProbabilitiesTrace(samples, categoryProbabilities);}
@@ -103,18 +116,21 @@ class ROCParameter : public Parameter
 
 		// poposal functions
 		void proposeCodonSpecificParameter();
-		void proposeHyperParameters();
+		void proposeAphi();
 		void getParameterForCategory(unsigned category, unsigned parameter, std::string aa, bool proposal, double *returnValue);
 
 		void adaptCodonSpecificParameterProposalWidth(unsigned adaptationWidth);
 
 
 		virtual void adaptSphiProposalWidth(unsigned adaptationWidth);
+		void adaptAphiProposalWidth(unsigned adaptationWidth);
 		virtual void adaptSynthesisRateProposalWidth(unsigned adaptationWidth);
 		virtual double getSphiPosteriorMean(unsigned samples);
+		double getAphiPosteriorMean(unsigned samples);
 		virtual std::vector <double> getEstimatedMixtureAssignmentProbabilities(unsigned samples, unsigned geneIndex);
 		virtual double getSynthesisRatePosteriorMean(unsigned samples, unsigned geneIndex, unsigned mixtureElement);
 		virtual double getSphiVariance(unsigned samples, bool unbiased = true );
+		double getAphiVariance(unsigned samples, bool unbiased = true);
 		virtual double getSynthesisRateVariance(unsigned samples, unsigned geneIndex, unsigned mixtureElement, bool unbiased = true);
 		double getMutationPosteriorMean(unsigned mixtureElement, unsigned samples, std::string &codon);
 		double getSelectionPosteriorMean(unsigned mixtureElement, unsigned samples, std::string &codon);
@@ -165,7 +181,6 @@ class ROCParameter : public Parameter
 		}
 
 	protected:
-
 };
 
 #endif // ROCPARAMETER_H

--- a/ribModel/src/include/ROC/ROCTrace.h
+++ b/ribModel/src/include/ROC/ROCTrace.h
@@ -10,6 +10,8 @@ class ROCTrace : public Trace
 	private:
 		std::vector<std::vector<std::vector<double>>> mutationParameterTrace; //order: mutationcategoy, numparam, samples
 		std::vector<std::vector<std::vector<double>>> selectionParameterTrace; //order: selectioncategoy, numparam, samples
+		std::vector<double> AphiTrace;
+		std::vector<double> AphiAcceptanceRatioTrace;
 
 	public:
 		//Constructor & Destructors
@@ -21,17 +23,21 @@ class ROCTrace : public Trace
 		void initROCTraces(unsigned samples, unsigned numMutationCategories, unsigned numSelectionCategories, unsigned numParam);
 		void initMutationParameterTrace(unsigned samples, unsigned numMutationCategories, unsigned numParam); 
 		void initSelectionParameterTrace(unsigned samples, unsigned numSelectionCategories, unsigned numParam); 
-
+		void initAphiTrace(unsigned samples);
 
 		//Getter functions
 		std::vector<double> getMutationParameterTraceByMixtureElementForCodon(unsigned mixtureElement, std::string& codon);
 		std::vector<double> getSelectionParameterTraceByMixtureElementForCodon(unsigned mixtureElement, std::string& codon);
+		std::vector<double> getAphiTrace() { return AphiTrace; }
+		std::vector<double> getAphiAcceptanceRatioTrace() { return AphiAcceptanceRatioTrace; }
+		
 
-    unsigned getMutationCategory(unsigned mixtureElement) {return categories->at(mixtureElement).delM;}
-    unsigned getSelectionCategory(unsigned mixtureElement) {return categories->at(mixtureElement).delEta;}
+		unsigned getMutationCategory(unsigned mixtureElement) {return categories->at(mixtureElement).delM;}
+		unsigned getSelectionCategory(unsigned mixtureElement) {return categories->at(mixtureElement).delEta;}
 		//Update functions	
 		void updateCodonSpecificParameterTrace(unsigned sample, std::string aa, std::vector<std::vector<double>> &curMutParam, std::vector<std::vector<double>> &curSelectParam);
-
+		void updateAphiTrace(unsigned sample, double value) { AphiTrace[sample] = value; }
+		void updateAphiAcceptanceRatioTrace(double value) { AphiAcceptanceRatioTrace.push_back(value); }
 		//R WRAPPER FUNCTIONS
 
 		//Getter functions

--- a/ribModel/src/include/base/Model.h
+++ b/ribModel/src/include/base/Model.h
@@ -47,6 +47,7 @@ class Model
 		virtual void updateSphi() = 0;
 		virtual void updateSphiTrace(unsigned sample) = 0;
 		virtual void adaptSphiProposalWidth(unsigned adaptiveWidth) = 0;
+		virtual void adaptHyperParameterProposalWidths(unsigned adaptiveWidth) = 0;
 		virtual void proposeSynthesisRateLevels() = 0;
 		virtual unsigned getNumSynthesisRateCategories() = 0;
 		virtual std::vector<unsigned> getMixtureElementsOfSelectionCategory(unsigned k) = 0;

--- a/ribModel/src/include/base/Parameter.h
+++ b/ribModel/src/include/base/Parameter.h
@@ -167,7 +167,7 @@ class Parameter {
 		virtual void updateMixtureProbabilitiesTrace(unsigned samples) = 0;
 
 		// proposal functions
-		virtual void proposeHyperParameters() = 0;
+		virtual void proposeSphi();
 		void proposeSynthesisRateLevels();
 		double getCurrentSynthesisRateProposalWidth(unsigned expressionCategory, unsigned geneIndex)
 		{

--- a/ribModel/src/include/base/Trace.h
+++ b/ribModel/src/include/base/Trace.h
@@ -10,7 +10,6 @@
 class Trace {
 	private:
 		std::vector<double> sPhiTrace; //samples
-		std::vector<double> aPhiTrace; //Not used yet
 		std::vector<double> sphiAcceptanceRatioTrace; //samples
 		std::vector<std::vector<std::vector<double>>>synthesisRateAcceptanceRatioTrace; //order: expressionCategory, gene, sample
 		std::vector<std::vector<double>> cspAcceptanceRatioTrace;//order: codon, sample
@@ -41,8 +40,6 @@ class Trace {
 		std::vector<double> getSPhiTrace()
 		{	return sPhiTrace;}
 		std::vector<double> getExpectedPhiTrace();
-		std::vector<double> getAPhiTrace()
-		{	return aPhiTrace;}
 		std::vector<double> getSphiAcceptanceRatioTrace()
 		{	return sphiAcceptanceRatioTrace;}
 		std::vector<double> getSynthesisRateAcceptanceRatioTraceByMixtureElementForGene(unsigned mixtureElement, unsigned geneIndex);

--- a/ribModel/src/main.cpp
+++ b/ribModel/src/main.cpp
@@ -180,7 +180,7 @@ void testSimulateGenome(Genome& genome)
 	parameter.InitializeSynthesisRate(phiVals);
 
 	std::cout << "done initialize ROCParameter object" << std::endl;
-	ROCModel model;
+	ROCModel model(false);
 	model.setParameter(parameter);
 	model.simulateGenome(genome);
 	std::vector <Gene> simGenes = genome.getGenes(true);
@@ -389,7 +389,7 @@ void simulateROCData()
 									   "/Users/roxasoath1/Desktop/RibModelFramework/ribModel/data/Skluyveri_CSP_ChrCleft.csv" };
 	tmp.initMutationSelectionCategories(files, tmp.getNumMutationCategories(), ROCParameter::dM);
 	tmp.initMutationSelectionCategories(files, tmp.getNumSelectionCategories(), ROCParameter::dEta);
-	ROCModel model;
+	ROCModel model(false);
 
 	model.setParameter(tmp);
 
@@ -638,7 +638,7 @@ int main()
 			}
 
 			std::cout <<"Initializing ROCModel object\n";
-			ROCModel model;
+			ROCModel model(false);
 			model.setParameter(parameter);
 			std::ofstream scuoout("results/scuo.csv");
 			for (unsigned n = 0u; n < genome.getGenomeSize(); n++)


### PR DESCRIPTION
Added a boolean withPhi to ROCmodel's constructor. This means that ROC
model can no longer be instantiated with "ROCmodel model", you must use
"ROCmodel model()". Also, a new pure virtual function in Model called
"adaptHyperParameterProposalWidths". This is so that hyper parameters
can be added or taken away from each specific model. As of now, Sphi is
required in all models, but other hyperparameters may be added now.
Also, I have added all of the trace things required for Aphi.