### PR TITLE
More overhead for "with phi" runs

### DIFF
--- a/ribModel/src/FONSEModel.cpp
+++ b/ribModel/src/FONSEModel.cpp
@@ -175,6 +175,11 @@ void FONSEModel::adaptHyperParameterProposalWidths(unsigned adaptiveWidth)
 	adaptSphiProposalWidth(adaptiveWidth);
 }
 
+void FONSEModel::updateHyperParameterTraces(unsigned sample)
+{
+	updateSphiTrace(sample);
+}
+
 void FONSEModel::setParameter(FONSEParameter &_parameter)
 {
 	parameter = &_parameter;

--- a/ribModel/src/MCMCAlgorithm.cpp
+++ b/ribModel/src/MCMCAlgorithm.cpp
@@ -209,7 +209,7 @@ void MCMCAlgorithm::acceptRejectHyperParameter(int numGenes, Model& model, int i
 
 	if((iteration % thining) == 0)
 	{
-		model.updateSphiTrace(iteration/thining);
+		model.updateHyperParameterTraces(iteration/thining);
 	}
 }
 
@@ -298,6 +298,7 @@ void MCMCAlgorithm::run(Genome& genome, Model& model, unsigned numCores)
 		// update hyper parameter
 		if(estimateHyperParameter)
 		{
+			model.updateGibbsSampledHyperParameters(genome);
 			model.proposeHyperParameters();
 			acceptRejectHyperParameter(genome.getGenomeSize(), model, iteration);
 			if( ( (iteration + 1u) % adaptiveWidth) == 0u)

--- a/ribModel/src/Parameter.cpp
+++ b/ribModel/src/Parameter.cpp
@@ -907,6 +907,21 @@ double Parameter::randExp(double r)
 	return rv;
 }
 
+double Parameter::randGamma(double shape, double rate)
+{
+	double rv;
+#ifndef STANDALONE
+	RNGScope scope;
+	NumericVector xx(1);
+	xx = rgamma(1, shape, rate = rate);
+	rv = xx[0];
+#else
+	std::gamma_distribution<double> distribution(shape, 1 / rate);
+	rv = distribution(generator);
+#endif
+	return rv;
+}
+
 
 void Parameter::randDirichlet(double* input, unsigned numElements, double* output)
 {

--- a/ribModel/src/RFPModel.cpp
+++ b/ribModel/src/RFPModel.cpp
@@ -186,3 +186,8 @@ void RFPModel::adaptHyperParameterProposalWidths(unsigned adaptiveWidth)
 {
 	adaptSphiProposalWidth(adaptiveWidth);
 }
+
+void RFPModel::updateHyperParameterTraces(unsigned sample)
+{
+	updateSphiTrace(sample);
+}

--- a/ribModel/src/ROCParameter.cpp
+++ b/ribModel/src/ROCParameter.cpp
@@ -109,6 +109,7 @@ void ROCParameter::initROCParameterSet()
 	Aphi = 0.0;
 	Aphi_proposed = 0.0;
 	std_Aphi = 0.1;
+	Sepsilon = 0.0;
 	numAcceptForAphi = 0;
 
 	//may need getter fcts

--- a/ribModel/src/ROCTrace.cpp
+++ b/ribModel/src/ROCTrace.cpp
@@ -22,6 +22,7 @@ void ROCTrace::initROCTraces(unsigned samples, unsigned numMutationCategories, u
 	initMutationParameterTrace(samples, numMutationCategories, numParam);
 	initSelectionParameterTrace(samples, numSelectionCategories, numParam);
 	initAphiTrace(samples);
+	initSepsilonTrace(samples);
 }
 
 
@@ -59,6 +60,11 @@ void ROCTrace::initSelectionParameterTrace(unsigned samples, unsigned numSelecti
 void ROCTrace::initAphiTrace(unsigned samples)
 {
 	AphiTrace.resize(samples);
+}
+
+void ROCTrace::initSepsilonTrace(unsigned samples)
+{
+	SepsilonTrace.resize(samples);
 }
 
 

--- a/ribModel/src/include/FONSE/FONSEModel.h
+++ b/ribModel/src/include/FONSE/FONSEModel.h
@@ -28,6 +28,8 @@ public:
 	virtual void calculateLogLikelihoodRatioPerGroupingPerCategory(std::string grouping, Genome& genome, double& logAcceptanceRatioForAllMixtures);
 	virtual void calculateLogLikelihoodRatioForHyperParameters(unsigned numGenes, unsigned iteration, double &logProbabilityRatio);
 
+	virtual void updateGibbsSampledHyperParameters(Genome &genome) {}
+
 	//Parameter wrapper functions:
 	virtual void initTraces(unsigned samples, unsigned num_genes) { parameter->initAllTraces(samples, num_genes); }
 	virtual void writeRestartFile(std::string filename) { return parameter->writeEntireRestartFile(filename); }
@@ -48,6 +50,7 @@ public:
 	virtual void adaptHyperParameterProposalWidths(unsigned adaptiveWidth);
 	virtual void updateSphi() { parameter->updateSphi(); }
 	virtual void updateSphiTrace(unsigned sample) { parameter->updateSphiTrace(sample); }
+	virtual void updateHyperParameterTraces(unsigned sample);
 	virtual void adaptSphiProposalWidth(unsigned adaptiveWidth) { parameter->adaptSphiProposalWidth(adaptiveWidth); }
 	virtual void proposeSynthesisRateLevels() { parameter->proposeSynthesisRateLevels(); }
 	virtual unsigned getNumSynthesisRateCategories() { return parameter->getNumSynthesisRateCategories(); }

--- a/ribModel/src/include/RFP/RFPModel.h
+++ b/ribModel/src/include/RFP/RFPModel.h
@@ -30,7 +30,7 @@ class RFPModel: public Model {
 		//Other functions:
 		void setParameter(RFPParameter &_parameter);
 		virtual void simulateGenome(Genome &genome);
-
+		virtual void updateGibbsSampledHyperParameters(Genome &genome) {}
 
 		//Parameter wrapper functions:
 		virtual void initTraces(unsigned samples, unsigned num_genes)
@@ -106,6 +106,7 @@ class RFPModel: public Model {
 		{
 			parameter->updateSphiTrace(sample);
 		}
+		virtual void updateHyperParameterTraces(unsigned sample);
 		virtual void adaptSphiProposalWidth(unsigned adaptiveWidth)
 		{
 			parameter->adaptSphiProposalWidth(adaptiveWidth);

--- a/ribModel/src/include/ROC/ROCModel.h
+++ b/ribModel/src/include/ROC/ROCModel.h
@@ -25,12 +25,14 @@ class ROCModel : public Model
 	void simulateGenome(Genome &genome);
 	virtual void calculateLogLikelihoodRatioForHyperParameters(unsigned numGenes, unsigned iteration, double &logProbabilityRatio);
 
+	virtual void updateGibbsSampledHyperParameters(Genome &genome);
 
 	//Parameter wrapper functions:
 	virtual void initTraces(unsigned samples, unsigned num_genes) {parameter -> initAllTraces(samples, num_genes);}
 	virtual void writeRestartFile(std::string filename) {return parameter->writeEntireRestartFile(filename);}       
 	virtual double getSphi(bool proposed = false) {return parameter->getSphi(proposed);}
 	double getAphi(bool proposed = false) { return parameter->getAphi(proposed); }
+	double getSepsilon() { return parameter->getSepsilon(); }
 	virtual unsigned getNumMixtureElements() {return parameter->getNumMixtureElements();}
 	virtual double getCategoryProbability(unsigned i) {return parameter->getCategoryProbability(i);}
 	virtual void proposeCodonSpecificParameter() {parameter->proposeCodonSpecificParameter();}
@@ -51,7 +53,9 @@ class ROCModel : public Model
 	virtual void adaptSphiProposalWidth(unsigned adaptiveWidth) {parameter->adaptSphiProposalWidth(adaptiveWidth);}
 	void updateAphi() { parameter->updateAphi(); }
 	void updateAphiTrace(unsigned sample) { parameter->updateAphiTrace(sample); }
+	void updateSepsilonTrace(unsigned sample) { parameter->updateSepsilonTrace(sample); }
 	void adaptAphiProposalWidth(unsigned adaptiveWidth) { parameter->adaptAphiProposalWidth(adaptiveWidth); }
+	virtual void updateHyperParameterTraces(unsigned sample);
 	virtual void proposeSynthesisRateLevels() {parameter->proposeSynthesisRateLevels();}
 	virtual unsigned getNumSynthesisRateCategories() {return parameter->getNumSynthesisRateCategories();}
 	virtual std::vector<unsigned> getMixtureElementsOfSelectionCategory(unsigned k) {return parameter->getMixtureElementsOfSelectionCategory(k);}
@@ -66,7 +70,7 @@ class ROCModel : public Model
 	{
 		parameter -> getParameterForCategory(category, param, aa, proposal, returnValue);
 	}
-	virtual unsigned getGroupListSize() {return parameter->getGroupListSize();} //TODO: make not hardcoded?
+	virtual unsigned getGroupListSize() {return parameter->getGroupListSize();} 
 	virtual std::string getGrouping(unsigned index) {return parameter -> getGrouping(index);}
 	// R wrapper
 	std::vector<double> CalculateProbabilitiesForCodons(std::vector<double> mutation, std::vector<double> selection, double phi);

--- a/ribModel/src/include/ROC/ROCParameter.h
+++ b/ribModel/src/include/ROC/ROCParameter.h
@@ -27,6 +27,7 @@ class ROCParameter : public Parameter
 		double phiEpsilon_proposed;
 		double Aphi;
 		double Aphi_proposed;
+		double Sepsilon;
 		double std_Aphi;
 		double numAcceptForAphi;
 
@@ -90,7 +91,7 @@ class ROCParameter : public Parameter
 		double getPreviousCodonSpecificProposalWidth(unsigned aa);
 		double getCurrentAphiProposalWidth() { return std_Aphi; }
 		// Phi epsilon functions
-		double getPhiEpsilon() {return phiEpsilon;}
+		double getPhiEpsilon() { return phiEpsilon; }
 
 
 		// functions to manage codon specific parameter
@@ -105,16 +106,20 @@ class ROCParameter : public Parameter
 			numAcceptForAphi++;
 		}
 
+		// functions to manage Sepsilon
+		double getSepsilon() { return Sepsilon; }
+		void setSepsilon(double se) { Sepsilon = se; }
 		//update trace functions
 		virtual void updateSphiTrace(unsigned sample) {traces.updateSphiTrace(sample, Sphi);}
 		void updateAphiTrace(unsigned sample) { traces.updateAphiTrace(sample, Aphi); }
+		void updateSepsilonTrace(unsigned sample) { traces.updateSepsilonTrace(sample, Sepsilon); }
 		virtual void updateSynthesisRateTrace(unsigned sample, unsigned geneIndex){traces.updateSynthesisRateTrace(sample, geneIndex, currentSynthesisRateLevel);}
 		virtual void updateMixtureAssignmentTrace(unsigned sample, unsigned geneIndex) {traces.updateMixtureAssignmentTrace(sample, geneIndex, mixtureAssignment[geneIndex]);}
 		virtual void updateMixtureProbabilitiesTrace(unsigned samples) {traces.updateMixtureProbabilitiesTrace(samples, categoryProbabilities);}
 		void updateCodonSpecificParameterTrace(unsigned sample, std::string grouping) {traces.updateCodonSpecificParameterTrace(sample, grouping, 
 			currentMutationParameter, currentSelectionParameter);}
 
-		// poposal functions
+		// proposal functions
 		void proposeCodonSpecificParameter();
 		void proposeAphi();
 		void getParameterForCategory(unsigned category, unsigned parameter, std::string aa, bool proposal, double *returnValue);

--- a/ribModel/src/include/ROC/ROCTrace.h
+++ b/ribModel/src/include/ROC/ROCTrace.h
@@ -12,6 +12,7 @@ class ROCTrace : public Trace
 		std::vector<std::vector<std::vector<double>>> selectionParameterTrace; //order: selectioncategoy, numparam, samples
 		std::vector<double> AphiTrace;
 		std::vector<double> AphiAcceptanceRatioTrace;
+		std::vector<double> SepsilonTrace;
 
 	public:
 		//Constructor & Destructors
@@ -24,12 +25,14 @@ class ROCTrace : public Trace
 		void initMutationParameterTrace(unsigned samples, unsigned numMutationCategories, unsigned numParam); 
 		void initSelectionParameterTrace(unsigned samples, unsigned numSelectionCategories, unsigned numParam); 
 		void initAphiTrace(unsigned samples);
+		void initSepsilonTrace(unsigned samples);
 
 		//Getter functions
 		std::vector<double> getMutationParameterTraceByMixtureElementForCodon(unsigned mixtureElement, std::string& codon);
 		std::vector<double> getSelectionParameterTraceByMixtureElementForCodon(unsigned mixtureElement, std::string& codon);
 		std::vector<double> getAphiTrace() { return AphiTrace; }
 		std::vector<double> getAphiAcceptanceRatioTrace() { return AphiAcceptanceRatioTrace; }
+		std::vector<double> getSepsilonTrace() { return SepsilonTrace; }
 		
 
 		unsigned getMutationCategory(unsigned mixtureElement) {return categories->at(mixtureElement).delM;}
@@ -38,6 +41,7 @@ class ROCTrace : public Trace
 		void updateCodonSpecificParameterTrace(unsigned sample, std::string aa, std::vector<std::vector<double>> &curMutParam, std::vector<std::vector<double>> &curSelectParam);
 		void updateAphiTrace(unsigned sample, double value) { AphiTrace[sample] = value; }
 		void updateAphiAcceptanceRatioTrace(double value) { AphiAcceptanceRatioTrace.push_back(value); }
+		void updateSepsilonTrace(unsigned sample, double value) { SepsilonTrace[sample] = value; }
 		//R WRAPPER FUNCTIONS
 
 		//Getter functions

--- a/ribModel/src/include/base/Model.h
+++ b/ribModel/src/include/base/Model.h
@@ -25,7 +25,7 @@ class Model
 
 		//Other functions:
 		virtual void simulateGenome(Genome &genome) =0;
-
+		virtual void updateGibbsSampledHyperParameters(Genome &genome) = 0;
 
 		//Parameter wrapper functions:
 		virtual void initTraces(unsigned samples, unsigned num_genes) = 0;
@@ -46,6 +46,7 @@ class Model
 		virtual double getCurrentSphiProposalWidth() = 0;
 		virtual void updateSphi() = 0;
 		virtual void updateSphiTrace(unsigned sample) = 0;
+		virtual void updateHyperParameterTraces(unsigned sample) = 0;
 		virtual void adaptSphiProposalWidth(unsigned adaptiveWidth) = 0;
 		virtual void adaptHyperParameterProposalWidths(unsigned adaptiveWidth) = 0;
 		virtual void proposeSynthesisRateLevels() = 0;

--- a/ribModel/src/include/base/Parameter.h
+++ b/ribModel/src/include/base/Parameter.h
@@ -197,6 +197,7 @@ class Parameter {
 		static double randNorm(double mean, double sd);
 		static double randLogNorm(double m, double s);
 		static double randExp(double r);
+		static double randGamma(double shape, double rate);
 		static void randDirichlet(double* input, unsigned numElements, double* output);
 		static double randUnif(double minVal, double maxVal);
 		static unsigned randMultinom(double* probabilities, unsigned mixtureElements);


### PR DESCRIPTION
Added overhead for Sepsilon and Gibbs Sampling for Sepsilon. Added new
function in parameter to generate a random gamma variable. 2 new pure
virtual functions in Model: updateGibbsSampledHyperParameters and
updateHyperParameterTraces. They're pretty self explanatory. I think
this is finally all of the overhead needed to add model-specific
hyperparameters. We'll see.