### PR TITLE
Aphi/Sepsilon plotting + new with phi stuff

### DIFF
--- a/ribModel/R/plotTraceObject.R
+++ b/ribModel/R/plotTraceObject.R
@@ -4,7 +4,7 @@
 # additional arguments are geneIndex, and category to index function like
 # getExpressionTraceForGene or plotCodonSpecificParameters
 
-plot.Rcpp_RFPTrace <- function(trace, what=c("Alpha", "LambdaPrime", "MixtureProbability" ,"SPhi", "ExpectedPhi", "Expression"), 
+plot.Rcpp_RFPTrace <- function(trace, what=c("Alpha", "LambdaPrime", "MixtureProbability" ,"Sphi", "ExpectedPhi", "Expression"), 
                                geneIndex=1, mixture = 1, ...)
 {
   if(what[1] == "Alpha")
@@ -19,9 +19,9 @@ plot.Rcpp_RFPTrace <- function(trace, what=c("Alpha", "LambdaPrime", "MixturePro
   {
     plotMixtureProbability(trace)
   }
-  if(what[1] == "SPhi")
+  if(what[1] == "Sphi")
   {
-    plotSPhiTrace(trace)
+    plotHyperParameterTrace(trace, what = what[1])
   }
   if(what[1] == "ExpectedPhi")
   {
@@ -32,8 +32,10 @@ plot.Rcpp_RFPTrace <- function(trace, what=c("Alpha", "LambdaPrime", "MixturePro
     plotExpressionTrace(trace, geneIndex)
   }
 }
-plot.Rcpp_ROCTrace <- function(trace, what=c("Mutation", "Selection", "MixtureProbability" ,"SPhi", "ExpectedPhi", "Expression"), 
-                                   geneIndex=1, mixture = 1, ...)
+
+# The `which' variable is the number of the trace to be plotted for Aphi and Sepsilon
+plot.Rcpp_ROCTrace <- function(trace, what=c("Mutation", "Selection", "MixtureProbability" ,"Sphi", "Mphi", "Aphi", "Sepsilon", "ExpectedPhi", "Expression"), 
+                                   geneIndex=1, mixture = 1, which = 1, ...)
 {
   if(what[1] == "Mutation")
   {
@@ -47,9 +49,20 @@ plot.Rcpp_ROCTrace <- function(trace, what=c("Mutation", "Selection", "MixturePr
   {
     plotMixtureProbability(trace)
   }
-  if(what[1] == "SPhi")
+  if(what[1] == "Sphi")
   {
-    plotSPhiTrace(trace)
+    plotHyperParameterTrace(trace, what = what[1])
+  }
+  if(what[1] == "Mphi") {
+    plotHyperParameterTrace(trace, what = what[1])
+  }
+  if(what[1] == "Aphi")
+  {
+    plotHyperParameterTrace(trace, what = what[1], which = which)
+  }
+  if(what[1] == "Sepsilon") 
+  {
+    plotHyperParameterTrace(trace, what = what[1], which = which)
   }
   if(what[1] == "ExpectedPhi")
   {
@@ -78,7 +91,7 @@ plot.Rcpp_FONSETrace <- function(trace, what=c("Mutation", "Selection", "Mixture
   }
   if(what[1] == "SPhi")
   {
-    plotSPhiTrace(trace)
+    plotHyperParameterTrace(trace, what = what[1])
   }
   if(what[1] == "ExpectedPhi")
   {
@@ -192,15 +205,32 @@ plotExpectedPhiTrace <- function(trace)
        main = expression("Trace of the Expected value of "~phi))
   abline(h=1, col="red", lwd=1.5, lty=2)
 }
-plotSPhiTrace <- function(trace)
+plotHyperParameterTrace <- function(trace, what = c("Sphi", "Mphi", "Aphi", "Sepsilon"), which = 1)
 {
-  opar <- par(no.readonly = T) 
-  par(oma=c(1,1,2,1), mgp=c(2,1,0), mar = c(3,4,2,1), mfrow=c(2, 1))
-  sphi <- trace$getSPhiTrace()
-  mphi <- -(sphi * sphi) / 2;
-  plot(mphi, type="l", xlab = "Sample", ylab = expression("m"[phi]))
-  plot(sphi, type="l", xlab = "Sample", ylab = expression("s"[phi]))
-  par(opar)
+#  opar <- par(no.readonly = T) 
+#  par(oma=c(1,1,2,1), mgp=c(2,1,0), mar = c(3,4,2,1), mfrow=c(2, 1))
+  if (what[1] == "Sphi")
+  {
+    sphi <- trace$getSphiTrace();
+    plot(sphi, type="l", xlab = "Sample", ylab = expression("s"[phi]))
+  }
+  if (what[1] == "Mphi")
+  {
+    sphi <- trace$getSphiTrace();
+    mphi <- -(sphi * sphi) / 2;
+    plot(mphi, type="l", xlab = "Sample", ylab = expression("m"[phi]));
+  }
+  if (what[1] == "Aphi") 
+  {
+    aphi <- trace$getAphiTrace(which);
+    plot(aphi, type="l", xlab = "Sample", ylab = expression("A"[phi]));
+  }
+  if (what[1] == "Sepsilon")
+  {
+    sepsilon <- trace$getSepsilonTrace(which);
+    plot(sepsilon, type="l", xlab = "Sample", ylab = expression("S"[epsilon]))
+  }
+  #par(opar)
 }
 plotMixtureProbability <- function(trace)
 {

--- a/ribModel/src/FONSEModel.cpp
+++ b/ribModel/src/FONSEModel.cpp
@@ -191,6 +191,12 @@ void FONSEModel::updateHyperParameterTraces(unsigned sample)
 	updateSphiTrace(sample);
 }
 
+void FONSEModel::printHyperParameters()
+{
+	std::cout << "\t current Sphi estimate: " << getSphi() << std::endl;
+	std::cout << "\t current Sphi proposal width: " << getCurrentSphiProposalWidth() << std::endl;
+}
+
 void FONSEModel::setParameter(FONSEParameter &_parameter)
 {
 	parameter = &_parameter;

--- a/ribModel/src/MCMCAlgorithm.cpp
+++ b/ribModel/src/MCMCAlgorithm.cpp
@@ -280,8 +280,7 @@ void MCMCAlgorithm::run(Genome& genome, Model& model, unsigned numCores)
 		{
 			std::cout << "Status at iteration " << (iteration+1) << std::endl;
 			std::cout << "\t current logLikelihood: " << likelihoodTrace[(iteration/thining) - 1] << std::endl;
-			std::cout << "\t current Sphi estimate: " << model.getSphi() << std::endl;
-			std::cout << "\t current Sphi proposal width: " << model.getCurrentSphiProposalWidth() << std::endl;
+			model.printHyperParameters();
 			for(unsigned i = 0u; i < model.getNumMixtureElements(); i++)
 			{
 				std::cout << "\t current Mixture element probability for element " << i << ": " << model.getCategoryProbability(i) << std::endl;

--- a/ribModel/src/RCPP_Trace.cpp
+++ b/ribModel/src/RCPP_Trace.cpp
@@ -31,9 +31,9 @@ RCPP_MODULE(Trace_mod)
     //These methods have specific R wrappers
     .method("getMutationParameterTraceByMixtureElementForCodon", &ROCTrace::getMutationParameterTraceByMixtureElementForCodonR)
     .method("getSelectionParameterTraceByMixtureElementForCodon", &ROCTrace::getSelectionParameterTraceByMixtureElementForCodonR)
-	.method("getAphiTrace", &ROCTrace::getAphiTrace)
+	.method("getAphiTrace", &ROCTrace::getAphiTraceR)
 	.method("getAphiAcceptanceRatioTrace", &ROCTrace::getAphiAcceptanceRatioTrace)
-	.method("getSepsilonTrace", &ROCTrace::getSepsilonTrace)
+	.method("getSepsilonTrace", &ROCTrace::getSepsilonTraceR)
     ;
 
 	class_<RFPTrace>("RFPTrace")

--- a/ribModel/src/RFPModel.cpp
+++ b/ribModel/src/RFPModel.cpp
@@ -201,3 +201,9 @@ void RFPModel::updateHyperParameterTraces(unsigned sample)
 {
 	updateSphiTrace(sample);
 }
+
+void RFPModel::printHyperParameters()
+{
+	std::cout << "\t current Sphi estimate: " << getSphi() << std::endl;
+	std::cout << "\t current Sphi proposal width: " << getCurrentSphiProposalWidth() << std::endl;
+}

--- a/ribModel/src/ROCModel.cpp
+++ b/ribModel/src/ROCModel.cpp
@@ -220,6 +220,31 @@ std::vector<double> ROCModel::CalculateProbabilitiesForCodons(std::vector<double
 	return returnVector;
 }
 
+void ROCModel::printHyperParameters()
+{
+	std::cout << "\t current Sphi estimate: " << getSphi() << std::endl;
+	std::cout << "\t current Sphi proposal width: " << getCurrentSphiProposalWidth() << std::endl;
+	std::cout << "\t current Aphi estimates:";
+	for (unsigned i = 0; i < getNumPhiGroupings(); i++) 
+	{
+		std::cout << " " << getAphi(i, false);
+	}
+	std::cout << std::endl;
+	std::cout << "\t current Aphi proposal widths:";
+	for (unsigned i = 0; i < getNumPhiGroupings(); i++)
+	{
+		std::cout << " " << getCurrentAphiProposalWidth(i);
+	}
+	std::cout << std::endl;
+	std::cout << "\t current Sepsilon estimates:";
+	for (unsigned i = 0; i < getNumPhiGroupings(); i++)
+	{
+		std::cout << " " << getSepsilon(i);
+	}
+	std::cout << std::endl;
+	
+}
+
 
 void ROCModel::simulateGenome(Genome &genome)
 {

--- a/ribModel/src/ROCParameter.cpp
+++ b/ribModel/src/ROCParameter.cpp
@@ -107,6 +107,13 @@ void ROCParameter::initROCParameterSet()
 
 	phiEpsilon = 0.1;
 	phiEpsilon_proposed = 0.1;
+	for (unsigned i = 0; i < getNumPhiGroupings(); i++) {
+		Aphi[i] = 0.0;
+		Aphi_proposed[i] = 0.0;
+		std_Aphi[i] = 0.1;
+		Sepsilon[i] = 0.0;
+		numAcceptForAphi[i] = 0;
+	}
 
 	//may need getter fcts
 	currentMutationParameter.resize(numMutationCategories);
@@ -567,11 +574,11 @@ void ROCParameter::initSelectionCategories(std::vector<std::string> files, unsig
 void ROCParameter::setNumPhiGroupings(unsigned _phiGroupings)
 {
 	phiGroupings = _phiGroupings;
-	Aphi.resize(phiGroupings, 0);
-	Aphi_proposed.resize(phiGroupings, 0);
+	Aphi.resize(phiGroupings, 0.0);
+	Aphi_proposed.resize(phiGroupings, 0.0);
 	std_Aphi.resize(phiGroupings, 0.1);
 	numAcceptForAphi.resize(phiGroupings, 0);
-	Sepsilon.resize(phiGroupings, 0);
+	Sepsilon.resize(phiGroupings, 0.0);
 }
 
 void ROCParameter::getParameterForCategory(unsigned category, unsigned paramType, std::string aa, bool proposal,

--- a/ribModel/src/ROCTrace.cpp
+++ b/ribModel/src/ROCTrace.cpp
@@ -138,3 +138,23 @@ std::vector<double> ROCTrace::getSelectionParameterTraceByMixtureElementForCodon
 	}
 	return RV;
 }
+
+std::vector<double> ROCTrace::getAphiTraceR(unsigned index)
+{
+	std::vector <double> rv;
+	bool checkTraceIndex = checkIndex(index, 1, AphiTrace.size());
+	if (checkTraceIndex) {
+		rv = getAphiTrace(index - 1);
+	}
+	return rv;
+}
+
+std::vector<double> ROCTrace::getSepsilonTraceR(unsigned index)
+{
+	std::vector <double> rv;
+	bool checkTraceIndex = checkIndex(index, 1, SepsilonTrace.size());
+	if (checkTraceIndex) {
+		rv = getSepsilonTrace(index - 1);
+	}
+	return rv;
+}

--- a/ribModel/src/include/FONSE/FONSEModel.h
+++ b/ribModel/src/include/FONSE/FONSEModel.h
@@ -74,6 +74,8 @@ public:
 	// R wrapper
 	//std::vector<double> CalculateProbabilitiesForCodons(std::vector<double> mutation, std::vector<double> selection, double phi);
 
+	virtual void printHyperParameters();
+
 protected:
 };
 

--- a/ribModel/src/include/RFP/RFPModel.h
+++ b/ribModel/src/include/RFP/RFPModel.h
@@ -172,6 +172,7 @@ class RFPModel: public Model {
 		std::vector<double> CalculateProbabilitiesForCodons(std::vector<double> mutation, std::vector<double> selection,
 				double phi);
 
+		virtual void printHyperParameters();
 	protected:
 };
 

--- a/ribModel/src/include/ROC/ROCModel.h
+++ b/ribModel/src/include/ROC/ROCModel.h
@@ -12,7 +12,6 @@ class ROCModel : public Model
 	virtual void obtainCodonCount(SequenceSummary& seqsum, std::string curAA, int codonCount[]);
 	double calculateLogLikelihoodPerAAPerGene(unsigned numCodons, int codonCount[], double mutation[], double selection[], double phiValue);
 	bool withPhi;
-	Genome *genome;
 
     public:
 
@@ -79,6 +78,7 @@ class ROCModel : public Model
 	// R wrapper
 	std::vector<double> CalculateProbabilitiesForCodons(std::vector<double> mutation, std::vector<double> selection, double phi);
 
+	virtual void printHyperParameters();
     protected:
 };
 

--- a/ribModel/src/include/ROC/ROCParameter.h
+++ b/ribModel/src/include/ROC/ROCParameter.h
@@ -135,7 +135,7 @@ class ROCParameter : public Parameter
 		double getAphiPosteriorMean(unsigned index, unsigned samples);
 		virtual std::vector <double> getEstimatedMixtureAssignmentProbabilities(unsigned samples, unsigned geneIndex);
 		virtual double getSynthesisRatePosteriorMean(unsigned samples, unsigned geneIndex, unsigned mixtureElement);
-		virtual double getSphiVariance(unsigned samples, bool unbiased = true );
+		virtual double getSphiVariance(unsigned samples, bool unbiased = true);
 		double getAphiVariance(unsigned index, unsigned samples, bool unbiased = true);
 		virtual double getSynthesisRateVariance(unsigned samples, unsigned geneIndex, unsigned mixtureElement, bool unbiased = true);
 		double getMutationPosteriorMean(unsigned mixtureElement, unsigned samples, std::string &codon);

--- a/ribModel/src/include/ROC/ROCTrace.h
+++ b/ribModel/src/include/ROC/ROCTrace.h
@@ -47,6 +47,8 @@ class ROCTrace : public Trace
 		//Getter functions
 		std::vector<double> getMutationParameterTraceByMixtureElementForCodonR(unsigned mixtureElement, std::string& codon); //R WRAPPER 
 		std::vector<double> getSelectionParameterTraceByMixtureElementForCodonR(unsigned mixtureElement, std::string& codon); //R WRAPPER
+		std::vector<double> getAphiTraceR(unsigned index);
+		std::vector<double> getSepsilonTraceR(unsigned index);
 };
 
 #endif //ROCTRACE_H

--- a/ribModel/src/include/base/Model.h
+++ b/ribModel/src/include/base/Model.h
@@ -66,6 +66,9 @@ class Model
 		virtual unsigned getGroupListSize() = 0;
 		virtual std::string getGrouping(unsigned index) = 0;
 
+		// print functions
+		virtual void printHyperParameters() = 0;
+
 	protected:
 };
 

--- a/ribModel/src/include/base/Parameter.h
+++ b/ribModel/src/include/base/Parameter.h
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <set>
 #include <fstream>
-#include <ctime>ROC
+#include <ctime>
 #ifndef STANDALONE
 #include <Rcpp.h>
 #endif


### PR DESCRIPTION
MCMC algorithm will now print out all hyperparameters. This is done in a
new pure virtual function in model called printHyperParameters. The
other models have already been updated with this change. There is still
some trickery going on with Aphi and Sepsilon that needs to be looked
at, however.