### PR TITLE
Optimization in FONSE and Typo in ROC

### DIFF
--- a/src/FONSEModel.cpp
+++ b/src/FONSEModel.cpp
@@ -692,9 +692,13 @@ void FONSEModel::calculateCodonProbabilityVector(unsigned numCodons, unsigned po
 		codonProb[numCodons - 1] = 1.0;
 	}
 
-	for (unsigned i = 0; i < numCodons; i++) {
-		codonProb[i] /= denominator;
-	}
+	//As is found in ROCModel.cpp, multiplication is a faster operation than division so we 
+	//save time here by dividing once and then muliplying numCodons times instead of dividing
+	//numCodons times.
+	denominator = 1 / denominator
+		for (unsigned i = 0; i < numCodons; i++) {
+			codonProb[i] *= denominator;
+		}
 }
 
 void FONSEModel::calculateCodonProbabilityVector(unsigned numCodons, unsigned position,
@@ -737,8 +741,12 @@ void FONSEModel::calculateCodonProbabilityVector(unsigned numCodons, unsigned po
 		codonProb[numCodons - 1] = 1.0;
 	}
 
+	//As is found in ROCModel.cpp, multiplication is a faster operation than division so we 
+	//save time here by dividing once and then muliplying numCodons times instead of dividing
+	//numCodons times.
+	denominator = 1/denominator
 	for (unsigned i = 0; i < numCodons; i++) {
-		codonProb[i] /= denominator;
+		codonProb[i] *= denominator;
 	}
 }
 

--- a/src/ROCModel.cpp
+++ b/src/ROCModel.cpp
@@ -793,7 +793,7 @@ void ROCModel::calculateCodonProbabilityVector(unsigned numCodons, double mutati
 		codonProb[numCodons - 1] = 1.0;
 	}
 
-	denominator = 1 / denominator; // Multiplication is faster than devition: replace multiple divisions below by one up here.
+	denominator = 1 / denominator; // Multiplication is faster than division: replace multiple divisions below by one up here.
 	// normalize codon probabilities
 	for (unsigned i = 0u; i < numCodons; i++)
 		codonProb[i] = codonProb[i] * denominator; // denominator is 1/denominator. see above


### PR DESCRIPTION
Changed series of divisions in FONSE to one division and a series of
multiplications so that it matches ROC. Also fixed a typo in ROCModel's
documentation.