### PR TITLE
Allowing for fixed Sepsilon -- please read changes

### DIFF
--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -1778,13 +1778,14 @@ double Parameter::randExp(double r)
 }
 
 
-/* The R version and C++ differ because C++ uses the
-// shape and scale parameter version while R uses the
-// shape and rate. */
 double Parameter::randGamma(double shape, double rate)
 {
 	double rv;
 #ifndef STANDALONE
+	/* Note that the rgamma() function called with Rcpp uses
+	// shape and scale parameters.  This is different from how 
+	// rgamma() behaves within an R session which uses shape and rate
+	*/
 	RNGScope scope;
 	NumericVector xx(1);
 	xx = rgamma(1, shape, 1.0 / rate);

--- a/src/ROCModel.cpp
+++ b/src/ROCModel.cpp
@@ -598,57 +598,50 @@ void ROCModel::updateCodonSpecificParameter(std::string grouping)
 
 void ROCModel::updateGibbsSampledHyperParameters(Genome &genome)
 {
-  //estimate s_epsilon by sampling from a gamma distribution
-	// TODO: Fix this for any numbers of phi values
-	if (withPhi)
-	{
-		double shape = ((double)genome.getGenomeSize() - 1.0) / 2.0;
-		for (unsigned i = 0; i < parameter->getNumObservedPhiSets(); i++)
-		{
-			double rate = 0.0; //Prior on s_epsilon goes here?
-			unsigned mixtureAssignment;
-			double noiseOffset = getNoiseOffset(i);
-			for (unsigned j = 0; j < genome.getGenomeSize(); j++)
-			{
-				mixtureAssignment = getMixtureAssignment(j);
-				double obsPhi = genome.getGene(j).getObservedSynthesisRate(i);
-				if (obsPhi > -1.0)
-				{
-					double sum = std::log(obsPhi) - noiseOffset - std::log(getSynthesisRate(j, mixtureAssignment, false));
-					rate += (sum * sum);
-				}else{
-				        // missing observation.
-					shape -= 0.5; 
-					//Reduce shape because initial estimate assumes there are no missing observations
-				}
-			}
-			rate /= 2.0;
-			double rand = parameter->randGamma(shape, rate);
-			//mikeg: There appears to be an error when using R
-			// that is when #ifndef STANDALONE evaluates true
-			// see note in Parameter.cpp: randGamma
-			// There it effectively uses: T \sim rgamma(1, shape, rate=1.0 / rate)
-			//
-			// Note, using Gelman BDA 3rd Ed as a guide,
-			// If $T\sim\text{Gamma(\alpha, \beta)}, then
-			// $1/T \sim \text{Inv-Gamma}(\alpha, \beta) $
-			// Where $\beta$ is the rate term in the Gamma.
+  double fixedSepsilon = 0.5; //value to use if not being estimated.
+  bool estSepsilon = true //flag for whether or not to estimate Sepsilon
+    //ultimately want to make the flag and fixedSepsilon values that can be set by the user.  
+    //estimate s_epsilon by sampling from a gamma distribution
+    
+    // TODO: Fix this for any numbers of phi values-- mikeg:what's broken here?
+    if (withPhi)
+      {
+	if(estSepsilon)
+	  {
+	    double shape = ((double)genome.getGenomeSize() - 1.0) / 2.0;
+	    for (unsigned i = 0; i < parameter->getNumObservedPhiSets(); i++)
+	      {
+		double rate = 0.0; //Prior on s_epsilon goes here?
+		unsigned mixtureAssignment;
+		double noiseOffset = getNoiseOffset(i);
+		for (unsigned j = 0; j < genome.getGenomeSize(); j++)
+		  {
+		    mixtureAssignment = getMixtureAssignment(j);
+		    double obsPhi = genome.getGene(j).getObservedSynthesisRate(i);
+		    if (obsPhi > -1.0)
+		      {
+			double sum = std::log(obsPhi) - noiseOffset - std::log(getSynthesisRate(j, mixtureAssignment, false));
+			rate += (sum * sum);
+		      }else{
+		      // missing observation.
+		      // We need to reduce shape because initial calculation
+		      // assumes there are no missing observations
 
-			
-			// Below the gamma sample is transformed into an inverse gamma sample
-			// However, according to Gilchrist et al (2015) Supporting Materials p. S6
-			// The sample 1/T is supposed to be equal to $s_\epsilon^2$,
-			// but here we appear to be setting $s_\epsilon = 1/T$.
-			// Thus we are off by a factor of $\sqrt{1/T}$.
-			// I've checked the function parameter::densityNorm() and it takes the sd
-			// not the variance
-			// parameter->setObservedSynthesisNoise(i, 1.0/rand);//INCORRECT
-			
-			double sepsilon = std::sqrt(1.0/rand);
-			parameter->setObservedSynthesisNoise(i, sepsilon);//Correct
-		}
-	}
+		      shape -= 0.5; 
+		    }
+		  }
+		rate /= 2.0;//prior on sEpsilon goes here as well?
+		double rand = parameter->randGamma(shape, rate);
+		double sepsilon = std::sqrt(1.0/rand);
+	      }
+	  }else
+	  { //don't estimate Sepsilon
+	    sepsilon = fixedSepsilon;
+	  }
+	parameter->setObservedSynthesisNoise(i, sepsilon);//Correct
+      }
 }
+
 
 
 void ROCModel::updateAllHyperParameter()


### PR DESCRIPTION
updated comments regarding sEpsilon sampling from InverseGamma.
Hard coded variables estSepsilon=true and fixedSepsilon=0.5 values for when estSepsilon is set to false.
These parameters should be altered so that they can be changed by the user.