### PR TITLE
Fixed genome indexing issue in getGenomeForGeneIndicesR

### DIFF
--- a/src/Genome.cpp
+++ b/src/Genome.cpp
@@ -837,7 +837,7 @@ Genome Genome::getGenomeForGeneIndicesR(std::vector <unsigned> indices, bool sim
 		}
 		else
 		{
-			simulated ? genome.addGene(simulatedGenes[indices[i]], true) : genome.addGene(genes[indices[i]], false);
+			simulated ? genome.addGene(simulatedGenes[indices[i]-1], true) : genome.addGene(genes[indices[i]-1], false);
 		}
 	}
 


### PR DESCRIPTION
I thought this was already fixed. Am I not seeing something?